### PR TITLE
Fix nullpointer when getting user profile without internet connection

### DIFF
--- a/android/src/main/java/com/xda/one/api/misc/Result.java
+++ b/android/src/main/java/com/xda/one/api/misc/Result.java
@@ -35,7 +35,7 @@ public class Result {
             inputStream = response.getBody().in();
             final String output = IOUtils.toString(inputStream);
             return Result.parseResultFromString(output);
-        } catch (IOException e) {
+        } catch (IOException | NullPointerException e) {
             e.printStackTrace();
         } finally {
             IOUtils.closeQuietly(inputStream);


### PR DESCRIPTION
Quick fix for an issue 
https://github.com/xda/XDA-One/issues/21

When response is null, it just shows 'Something went wrong' message.
