### PR TITLE
Support copying text from posts, quotes and messages

### DIFF
--- a/android/src/main/java/com/xda/one/util/SectionUtils.java
+++ b/android/src/main/java/com/xda/one/util/SectionUtils.java
@@ -159,6 +159,7 @@ public class SectionUtils {
         view.setTextColor(Color.DKGRAY);
         view.setTextSize(Dimension.UNIT_SP, 13);
         view.setPadding(16, 16, 16, 16);
+        view.setTextIsSelectable(true);
         return view;
     }
 
@@ -170,6 +171,7 @@ public class SectionUtils {
         view.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT, WRAP_CONTENT));
         view.setTextColor(Color.BLACK);
         view.setTextSize(Dimension.UNIT_SP, 13);
+        view.setTextIsSelectable(true);
         return view;
     }
 }

--- a/android/src/main/res/layout/message_list_item.xml
+++ b/android/src/main/res/layout/message_list_item.xml
@@ -59,7 +59,8 @@
         android:singleLine="true"
         android:text="@string/message_content"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textSize="13sp" />
+        android:textSize="13sp"
+        android:textIsSelectable="true"/>
 
     <TextView
         android:id="@+id/messsage_list_item_last_post"


### PR DESCRIPTION
This enables the inbuilt system copy-paste feature for posts, quotes and private messages. Longer term, we should support sharing posts using the system features, but for now this means it's possible to at least copy-paste text if needed.
