### PR TITLE
Resolve #33 - Downloads go to a subfolder of system downloads

### DIFF
--- a/android/src/main/java/com/xda/one/ui/PostFragment.java
+++ b/android/src/main/java/com/xda/one/ui/PostFragment.java
@@ -30,6 +30,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Environment;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager;
@@ -396,7 +397,7 @@ public class PostFragment extends Fragment
             final DownloadManager.Request request = new DownloadManager
                     .Request(Uri.parse(a.getAttachmentUrl()))
                     .setAllowedOverRoaming(false)
-                    .setDestinationInExternalPublicDir("XDA-One-Downloads", a.getFileName());
+                    .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS + "/XDA One/", a.getFileName());
             manager.enqueue(request);
         }
     }


### PR DESCRIPTION
This resolves issue #33 and makes sense - making new folders in the root of the user storage partition isn't particularly good behaviour
