### PR TITLE
Use escape for apostrophes that's understood by the parser

### DIFF
--- a/android/src/main/assets/xda.xml
+++ b/android/src/main/assets/xda.xml
@@ -10,7 +10,7 @@
         </code>
         <code priority="100">
             <pattern>&apos;</pattern>
-            <template>&amp;apos;</template>
+            <template>&amp;#39;</template>
         </code>
         <code priority="100">
             <pattern>&lt;</pattern>


### PR DESCRIPTION
At the moment, apostrophes simply don't appear anywhere in posts. They're removed by the parser.

This is because `&apos;` doesn't seem to be understood by the used BBCode to HTML parsing library. `&apos;` [doesn't seem to be valid a HTML entity reference](http://fishbowl.pastiche.org/2003/07/01/the_curse_of_apos/). Using the apostrophe's unicode character `&#39;` instead fixes the issue.
